### PR TITLE
Update for Battle for Azeroth

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,7 @@
 std = 'lua51'
 
 ignore = {
+	'431', -- upvalue shadowing
 	'631', -- Line is too long
 }
 

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,19 +6,28 @@ ignore = {
 
 read_globals = {
 	-- CONSTANTS
-	'ARTIFACT_POWER_TOOLTIP_BODY', 'ARTIFACT_POWER_TOOLTIP_TITLE', 'HIGHLIGHT_FONT_COLOR', 'INVSLOT_MAINHAND',
+	'ARTIFACT_BAR_COLOR', 'ARTIFACT_POWER_TOOLTIP_BODY', 'ARTIFACT_POWER_TOOLTIP_TITLE',
+	'AZERITE_POWER_TOOLTIP_BODY', 'AZERITE_POWER_TOOLTIP_TITLE', 'HIGHLIGHT_FONT_COLOR', 'INVSLOT_MAINHAND',
 
 	-- API
-	'AbbreviateLargeNumbers', 'GetInventoryItemEquippedUnusable', 'HasArtifactEquipped',
-	'MainMenuBar_GetNumArtifactTraitsPurchasableFromXP', 'SocketInventoryItem', 'UnitHasVehicleUI',
+	'AbbreviateLargeNumbers', 'CreateColor', 'GetInventoryItemEquippedUnusable', 'GetInventoryItemLink',
+	'HasArtifactEquipped', 'SocketInventoryItem', 'UnitHasVehicleUI',
 
 	-- Widgets
 	'GameTooltip',
 
+	-- Mixins
+	'Item',
+
 	-- Namespaces
 	C_ArtifactUI = {
 		fields = {
-			'GetEquippedArtifactInfo',
+			'GetCostForPointAtRank', 'GetEquippedArtifactInfo',
+		},
+	},
+	C_AzeriteItem = {
+		fields = {
+			'FindActiveAzeriteItem', 'GetAzeriteItemXPInfo', 'GetPowerLevel',
 		},
 	},
 	'oUF',

--- a/oUF_ArtifactPower.lua
+++ b/oUF_ArtifactPower.lua
@@ -242,7 +242,8 @@ local function UpdateColor(element, isUsable)
 	element:SetStatusBarColor(unpack(color))
 end
 
-local function Update(self, event, unit)
+local function Update(self, event, arg)
+	local unit = type(arg) == 'string' and arg
 	if (unit and unit ~= self.unit) then return end
 	local element = self.ArtifactPower
 

--- a/oUF_ArtifactPower.lua
+++ b/oUF_ArtifactPower.lua
@@ -9,21 +9,11 @@ ArtifactPower - a `StatusBar` used to display the player's artifact power
 
 ## Options
 
-.color         - the RGB values for the widget. Defaults to {.901, .8, .601} (table)
+.color         - the RGB values for the widget. Defaults to `ARTIFACT_POWER_BAR:GetRGB()` (table)
 .onAlpha       - alpha value of the widget when it is mouse-enabled and hovered. Defaults to 1 (number)[0-1]
 .offAlpha      - alpha value of the widget when it is mouse-enabled and not hovered. Defaults to 1 (number)[0-1]
 .tooltipAnchor - anchor point for the tooltip. Defaults to 'ANCHOR_BOTTOMRIGHT' (string)
 .unusableColor - the RGB values for the widget when the equipped artifact is unusable. Defaults to {1, 0, 0} (table)
-
-## Attributes
-
-.name               - the name of the currently equipped artifact (string)
-.power              - the amount of artifact power earned towards the next artifact trait (number)
-.powerForNextTrait  - the amount of artifact power needed for the next artifact trait (number)
-.totalPower         - the total amount of unspent artifact power (number)
-.numTraitsLearnable - the number of traits that could be purchased with the current amount of unspent artifact power (number)
-.traitsLearned      - the number of purchased traits (number)
-.tier               - the current artifact tier (number)
 
 ## Notes
 
@@ -50,61 +40,129 @@ by the layout.
 local _, ns = ...
 local oUF = ns.oUF or oUF
 
+local ARTIFACT_BAR_COLOR = ARTIFACT_BAR_COLOR or CreateColor(0.901, 0.8, 0.601, 1)
+
+local ItemDataLoadedCancelFunc, azeriteItemLocation
+
+local function GetNumTraitsLearnable(numTraitsLearned, power, tier)
+	local numPoints = 0;
+	local powerForNextTrait = C_ArtifactUI.GetCostForPointAtRank(numTraitsLearned, tier)
+	while power >= powerForNextTrait and powerForNextTrait > 0 do
+		power = power - powerForNextTrait
+
+		numTraitsLearned = numTraitsLearned + 1
+		numPoints = numPoints + 1
+
+		powerForNextTrait = C_ArtifactUI.GetCostForPointAtRank(numTraitsLearned, tier)
+	end
+	return numPoints, power, powerForNextTrait
+end
+
 for tag, func in next, {
 	['artifactpower:name'] = function()
-		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, name = C_ArtifactUI.GetEquippedArtifactInfo()
-		return name
+		if (not UnitHasVehicleUI('player')) then
+			local azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+			if (azeriteItemLocation) then
+				local link = GetInventoryItemLink('player', azeriteItemLocation.equipmentSlotIndex)
+				return link and link:match('%[(.+)%]')
+			elseif (HasArtifactEquipped()) then
+				local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+				local _, power = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+				return power
+			end
+		end
 	end,
 	['artifactpower:power'] = function()
-		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, totalPower, traitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
-		local _, power = MainMenuBar_GetNumArtifactTraitsPurchasableFromXP(traitsLearned, totalPower, tier)
-		return power
+		if (not UnitHasVehicleUI('player')) then
+			local azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+			if (azeriteItemLocation) then
+				local power = C_AzeriteItem.GetAzeriteItemXPInfo(azeriteItemLocation)
+				return power
+			elseif (HasArtifactEquipped()) then
+				local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+				local _, power = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+				return power
+			end
+		end
 	end,
 	['artifactpower:until_next'] = function()
-		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, totalPower, traitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
-		local _, power, powerForNextTrait = MainMenuBar_GetNumArtifactTraitsPurchasableFromXP(traitsLearned, totalPower, tier)
-		return powerForNextTrait - power
+		if (not UnitHasVehicleUI('player')) then
+			local azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+			if (azeriteItemLocation) then
+				local power, max = C_AzeriteItem.GetAzeriteItemXPInfo(azeriteItemLocation)
+				return max - power
+			elseif (HasArtifactEquipped()) then
+				local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+				local _, power, powerForNextTrait = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+				return powerForNextTrait - power
+			end
+		end
 	end,
 	['artifactpower:until_next_per'] = function()
-		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, totalPower, traitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
-		local _, power, powerForNextTrait = MainMenuBar_GetNumArtifactTraitsPurchasableFromXP(traitsLearned, totalPower, tier)
-		return math.floor(((power / powerForNextTrait) * 100) + 0.5)
+		if (not UnitHasVehicleUI('player')) then
+			local azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+			if (azeriteItemLocation) then
+				local power, max = C_AzeriteItem.GetAzeriteItemXPInfo(azeriteItemLocation)
+				return math.floor(power / max * 100 + 0.5)
+			elseif (HasArtifactEquipped()) then
+				local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+				local _, power, powerForNextTrait = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+				return math.floor(power / powerForNextTrait * 100 + 0.5)
+			end
+		end
 	end,
-	['artifactpower:next_trait_cost'] = function()
-		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, totalPower, traitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
-		local _, _, powerForNextTrait = MainMenuBar_GetNumArtifactTraitsPurchasableFromXP(traitsLearned, totalPower, tier)
-		return powerForNextTrait
+	['artifactpower:total_until_next'] = function() -- was next_trait_cost
+		if (not UnitHasVehicleUI('player')) then
+			local azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+			if (azeriteItemLocation) then
+				local _, max = C_AzeriteItem.GetAzeriteItemXPInfo(azeriteItemLocation)
+				return max
+			elseif (HasArtifactEquipped()) then
+				local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+				local _, _, powerForNextTrait = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+				return powerForNextTrait
+			end
+		end
 	end,
-	['artifactpower:total'] = function()
+	['artifactpower:unspent_power'] = function() -- was total
 		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, totalPower = C_ArtifactUI.GetEquippedArtifactInfo()
-		return totalPower
+		local _, _, _, _, unspentPower = C_ArtifactUI.GetEquippedArtifactInfo()
+		return unspentPower
 	end,
 	['artifactpower:traits_learnable'] = function()
 		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, totalPower, traitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
-		local numTraitsLearnable = MainMenuBar_GetNumArtifactTraitsPurchasableFromXP(traitsLearned, totalPower, tier)
+		local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+		local numTraitsLearnable = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
 		return numTraitsLearnable
 	end,
 	['artifactpower:traits_learned'] = function()
 		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
-		local _, _, _, _, _, traitsLearned = C_ArtifactUI.GetEquippedArtifactInfo()
-		return traitsLearned
+		local _, _, _, _, _, numTraitsLearned = C_ArtifactUI.GetEquippedArtifactInfo()
+		return numTraitsLearned
 	end,
 	['artifactpower:tier'] = function()
 		if (not HasArtifactEquipped() or UnitHasVehicleUI('player')) then return end
 		local _, _, _, _, _, _, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
 		return tier
-	end
+	end,
+	['artifactpower:level'] = function()
+		if (not UnitHasVehicleUI('player')) then
+			local azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+			if (azeriteItemLocation) then
+				return C_AzeriteItem.GetPowerLevel(azeriteItemLocation)
+			elseif (HasArtifactEquipped()) then
+				local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+				local numTraitsLearnable = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+				return numTraitsLearnable + numTraitsLearned
+			end
+		end
+	end,
 } do
 	oUF.Tags.Methods[tag] = func
-	oUF.Tags.Events[tag] = 'ARTIFACT_XP_UPDATE UNIT_INVENTORY_CHANGED'
+	oUF.Tags.Events[tag] = 'AZERITE_ITEM_EXPERIENCE_CHANGED ARTIFACT_XP_UPDATE UNIT_INVENTORY_CHANGED'
 end
+oUF.Tags.SharedEvents.AZERITE_ITEM_EXPERIENCE_CHANGED = true
+oUF.Tags.SharedEvents.ARTIFACT_XP_UPDATE = true
 
 --[[ Override: ArtifactPower:OnEnter()
 Called when the mouse cursor enters the widget's interactive area.
@@ -113,15 +171,30 @@ Called when the mouse cursor enters the widget's interactive area.
 --]]
 local function OnEnter(element)
 	element:SetAlpha(element.onAlpha)
-	GameTooltip:SetOwner(element, element.tooltipAnchor)
-	GameTooltip:SetText(element.name, HIGHLIGHT_FONT_COLOR:GetRGB())
-	GameTooltip:AddLine(' ')
-	GameTooltip:AddLine(ARTIFACT_POWER_TOOLTIP_TITLE:format(AbbreviateLargeNumbers(element.totalPower),
-	                                                        AbbreviateLargeNumbers(element.power),
-	                                                        AbbreviateLargeNumbers(element.powerForNextTrait)),
-	                    nil, nil, nil, true)
-	GameTooltip:AddLine(ARTIFACT_POWER_TOOLTIP_BODY:format(element.numTraitsLearnable), nil, nil, nil, true)
-	GameTooltip:Show()
+
+	if (azeriteItemLocation) then
+		local azeriteItem = Item:CreateFromItemLocation(azeriteItemLocation)
+		ItemDataLoadedCancelFunc = azeriteItem:ContinueWithCancelOnItemLoad(function()
+			GameTooltip:SetOwner(element, element.tooltipAnchor)
+			GameTooltip:SetText(AZERITE_POWER_TOOLTIP_TITLE:format(element.level, element.max - element.current), HIGHLIGHT_FONT_COLOR:GetRGB())
+			GameTooltip:AddLine(AZERITE_POWER_TOOLTIP_BODY:format(azeriteItem:GetItemName()))
+			GameTooltip:Show()
+		end)
+	elseif (HasArtifactEquipped()) then
+		local _, _, name = C_ArtifactUI.GetEquippedArtifactInfo()
+		GameTooltip:SetOwner(element, element.tooltipAnchor)
+		GameTooltip:SetText(name, HIGHLIGHT_FONT_COLOR:GetRGB())
+		GameTooltip:AddLine(
+			ARTIFACT_POWER_TOOLTIP_TITLE:format(
+				AbbreviateLargeNumbers(element.unspentPower),
+				AbbreviateLargeNumbers(element.current),
+				AbbreviateLargeNumbers(element.max)
+			),
+			nil, nil, nil, true
+		)
+		GameTooltip:AddLine(ARTIFACT_POWER_TOOLTIP_BODY:format(element.numTraitsLearnable), nil, nil, nil, true)
+		GameTooltip:Show()
+	end
 end
 
 --[[ Override: ArtifactPower:OnLeave()
@@ -130,21 +203,28 @@ Called when the mouse cursor leaves the widget's interactive area.
 * self - the ArtifactPower widget
 --]]
 local function OnLeave(element)
-	element:SetAlpha(element.offAlpha)
+	if (ItemDataLoadedCancelFunc) then
+		ItemDataLoadedCancelFunc()
+		ItemDataLoadedCancelFunc = nil
+	end
 	GameTooltip:Hide()
+	element:SetAlpha(element.offAlpha)
 end
 
 --[[ Override: ArtifactPower:OnMouseUp()
-Called to show the artifact UI if the widget is mouse-enabled and has been clicked
+Used to show the artifact UI if the widget is mouse-enabled and has been clicked.
+Only functions when a Legion artifact is equipped.
 
 * self - the ArtifactPower widget
 --]]
 local function OnMouseUp()
-	SocketInventoryItem(INVSLOT_MAINHAND)
+	if (HasArtifactEquipped()) then
+		SocketInventoryItem(INVSLOT_MAINHAND)
+	end
 end
 
 --[[ Override: ArtifactPower:UpdateColor(isUsable)
-Used to update the widget's color based whether the equipped artifact is usable.
+Used to update the widget's color based on whether the equipped artifact is usable.
 
 * self     - the ArtifactPower widget
 * isUsable - indicates whether the equipped artifact is usable (boolean)
@@ -156,52 +236,70 @@ end
 
 local function Update(self, event, unit)
 	if (unit and unit ~= self.unit) then return end
-
 	local element = self.ArtifactPower
+
 	--[[ Callback: ArtifactPower:PreUpdate(event)
 	Called before the element has been updated.
 
 	* self  - the ArtifactPower widget
 	* event - the event that triggered the update (string)
 	--]]
-	if (element.PreUpdate) then element:PreUpdate(event) end
+	if (element.PreUpdate) then
+		element:PreUpdate(event)
+	end
 
-	local isUsable = false
-	local show = HasArtifactEquipped() and not UnitHasVehicleUI('player')
+	local current, max, level, show
+	local isUsable = true
+	if (not UnitHasVehicleUI('player')) then
+		azeriteItemLocation = C_AzeriteItem and C_AzeriteItem.FindActiveAzeriteItem()
+		if (azeriteItemLocation) then
+			current, max = C_AzeriteItem.GetAzeriteItemXPInfo(azeriteItemLocation)
+			level = C_AzeriteItem.GetPowerLevel(azeriteItemLocation)
+			show = true
+		elseif (HasArtifactEquipped()) then
+			local _, _, _, _, unspentPower, numTraitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
+			local numTraitsLearnable, power, powerForNextTrait = GetNumTraitsLearnable(numTraitsLearned, unspentPower, tier)
+			current = power
+			max = powerForNextTrait
+			level = numTraitsLearnable + numTraitsLearned
+			isUsable = not GetInventoryItemEquippedUnusable('player', INVSLOT_MAINHAND)
+
+			element.numTraitsLearnable = numTraitsLearnable
+			element.unspentPower = unspentPower
+			show = true
+		end
+	end
+
+	element.current = current
+	element.max = max
+	element.level = level
+
 	if (show) then
-		local _, _, name, _, totalPower, traitsLearned, _, _, _, _, _, _, tier = C_ArtifactUI.GetEquippedArtifactInfo()
-		local numTraitsLearnable, power, powerForNextTrait
-			= MainMenuBar_GetNumArtifactTraitsPurchasableFromXP(traitsLearned, totalPower, tier);
-
-		element:SetMinMaxValues(0, powerForNextTrait)
-		element:SetValue(power)
-
-		element.name = name
-		element.power = power
-		element.powerForNextTrait = powerForNextTrait
-		element.totalPower = totalPower
-		element.numTraitsLearnable = numTraitsLearnable
-		element.traitsLearned = traitsLearned
-		element.tier = tier
-
-		isUsable = not GetInventoryItemEquippedUnusable('player', INVSLOT_MAINHAND)
 		element:UpdateColor(isUsable)
 
+		if (element.SetAnimatedValues) then
+			element:SetAnimatedValues(current, 0, max, level)
+		else
+			element:SetMinMaxValues(0, max)
+			element:SetValue(current)
+		end
 		element:Show()
 	else
 		element:Hide()
 	end
 
-	--[[ Callback: ArtifactPower:PostUpdate(event, isShown, isUsable)
+	--[[ Callback: ArtifactPower:PostUpdate(event, current, max, level, isUsable)
 	Called after the element has been updated.
 
 	* self     - the ArtifactPower widget
 	* event    - the event that triggered the update (string)
-	* isShown  - indicates whether the element is shown (boolean)
+	* current  - the amount of artifact power gained towards the next artifact level/trait (number)
+	* max      - the total amount of artifact power needed for the next artifact level/trait (number)
+	* level    - the current artifact level or the sum of learned and learnable traits (number)
 	* isUsable - indicates whether the equipped artifact is usable (boolean)
 	--]]
 	if (element.PostUpdate) then
-		return element:PostUpdate(event, show, isUsable)
+		return element:PostUpdate(event, current, max, level, isUsable)
 	end
 end
 
@@ -233,8 +331,8 @@ local function Enable(self, unit)
 		end
 	end
 
-	element.color = element.color or {.901, .8, .601}
-	element.unusableColor = element.unusableColor or {1, 0, 0}
+	element.color = element.color or { ARTIFACT_BAR_COLOR:GetRGB() }
+	element.unusableColor = element.unusableColor or { 1, 0, 0 }
 	element.UpdateColor = element.UpdateColor or UpdateColor
 
 	if (element:IsMouseEnabled()) then
@@ -242,6 +340,7 @@ local function Enable(self, unit)
 		element.onAlpha = element.onAlpha or 1
 		element.offAlpha = element.offAlpha or 1
 		element:SetAlpha(element.offAlpha)
+
 		if (not element:GetScript('OnEnter')) then
 			element:SetScript('OnEnter', element.OnEnter or OnEnter)
 		end
@@ -254,6 +353,7 @@ local function Enable(self, unit)
 	end
 
 	self:RegisterEvent('ARTIFACT_XP_UPDATE', Path, true)
+	self:RegisterEvent('AZERITE_ITEM_EXPERIENCE_CHANGED', Path, true)
 	self:RegisterEvent('UNIT_INVENTORY_CHANGED', Path)
 
 	return true
@@ -263,7 +363,13 @@ local function Disable(self)
 	local element = self.ArtifactPower
 	if (not element) then return end
 
+	if (ItemDataLoadedCancelFunc) then
+		ItemDataLoadedCancelFunc()
+		ItemDataLoadedCancelFunc = nil
+	end
+
 	self:UnregisterEvent('ARTIFACT_XP_UPDATE', Path)
+	self:UnregisterEvent('AZERITE_ITEM_EXPERIENCE_CHANGED', Path)
 	self:UnregisterEvent('UNIT_INVENTORY_CHANGED', Path)
 	element:Hide()
 end

--- a/oUF_ArtifactPower.lua
+++ b/oUF_ArtifactPower.lua
@@ -15,6 +15,14 @@ ArtifactPower - a `StatusBar` used to display the player's artifact power
 .tooltipAnchor - anchor point for the tooltip. Defaults to 'ANCHOR_BOTTOMRIGHT' (string)
 .unusableColor - the RGB values for the widget when the equipped artifact is unusable. Defaults to {1, 0, 0} (table)
 
+## Attributes
+
+.current            - the amount of artifact power gained towards the next artifact level/trait (number?)
+.max                - the total amount of artifact power needed for the next artifact level/trait (number?)
+.level              - the current artifact level or the sum of learned and learnable traits (number?)
+.unspentPower       - the amount of unspent artifact power (number?)
+.numTraitsLearnable - the number of learnable traits based on the amount of unspent artifact power (number?)
+
 ## Notes
 
 A default texture will be applied if the widget is a `StatusBar` and doesn't have a texture or color set.


### PR DESCRIPTION
What was added:
- support for BfA azerite power (the Heart of Azeroth will be prioritized over Legion artifacts if you can have both at once)
- support for AnimatedStatusBars
- new tag `artifactpower:level`

Breaking changes:
- the tag `artifactpower:next_trait_cost` is now named `artifactpower:total_until_next`
- the tag `artifactpower:total` is now named `artifactpower:unspent_power`
- the element attributes are changed and their use is discouraged as it proves difficult to retain compatibility. Use the tags instead (I'll try to keep tag names unchanged from now on) or keep using the attributes if you don't mind me changing my mind about naming. Here is the current list:  
  - `.current` - the amount of artifact power gained towards the next artifact level/trait (the current bar value; previously named `.power`)
  - `.max` - the total amount of artifact power needed for the next artifact level/trait (the bar max value; previously named `.powerForNextTrait`)
  - `.level` - the current artifact level or the sum of learned and learnable traits
  - `.unspentPower` - the amount of unspent artifact power (previously named `.totalPower`). Only used for Legion artifacts
  - `.numTraitsLearnable` - the number of traits you can learn based on the amount of unspent artifact power. Only used for Legion artifacts
- `PostUpdate` has new arguments (current, max and level in place of the old show)

What was fixed:
- ARTIFACT_XP_UPDATE is a unitless event and has been added to `oUF.Tags.SharedEvents`. Apparently nobody used the tags anyway

Use with caution:
- the tags are all drycoded
- the Legion artifacts support for the Beta is untested (no character copy yet, so can't test)

Why so many changes:
- Technically artifact power is split between two different systems (azerite and artifact power). This one is on Blizzard.
- I can't make up my mind on naming. This one is on me but blame Blizzard though.

Feedback needed:
- Feel free to complain or share bugs or both